### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#SSM集成的基础项目，项目使用Maven管理
+# SSM集成的基础项目，项目使用Maven管理
 
-#MyBatis3.3.0
+# MyBatis3.3.0
 
-#Spring[MVC]4.1.2.RELEASE
+# Spring[MVC]4.1.2.RELEASE
 
 项目使用Spring4.1.2.RELEASE + SpringMVC4.1.2.RELEASE + Mybatis3.3.0
 
@@ -42,23 +42,23 @@
 - 原来的 `dialect` 变成了 `helperDialect`，这是基于 PageHelper 方式的分页
 - 具体变化看文档
 
-##Spring Boot集成MyBatis的基础项目
+## Spring Boot集成MyBatis的基础项目
 
-###https://github.com/abel533/MyBatis-Spring-Boot
+### https://github.com/abel533/MyBatis-Spring-Boot
 
-##MyBatis工具
+## MyBatis工具
 
-###http://www.mybatis.tk
+### http://www.mybatis.tk
 
-##推荐使用Mybatis通用Mapper3
+## 推荐使用Mybatis通用Mapper3
 
-###https://github.com/abel533/Mapper
+### https://github.com/abel533/Mapper
 
-##推荐使用Mybatis分页插件PageHelper
+## 推荐使用Mybatis分页插件PageHelper
 
-###https://github.com/pagehelper/Mybatis-PageHelper
+### https://github.com/pagehelper/Mybatis-PageHelper
 
-##作者信息
+## 作者信息
 
 - 作者博客：http://blog.csdn.net/isea533
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
