### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.4.2组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.isea533</groupId>
     <artifactId>mybatis-spring</artifactId>
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.4.2</version>
+            <version>2.9.10.8</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML Jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.4.2
漏洞编号：CVE-2017-17485
漏洞描述：FasterXML jackson-databind是一个基于JAVA可以将XML和JSON等数据格式与JAVA对象进行转换的库。Jackson可以轻松的将Java对象转换成json对象和xml文档，同样也可以将json、xml转换成Java对象。
FasterXML Jackson-databind 2.8.10及之前版本和2.9.x版本至2.9.3版本中存在代码问题漏洞。远程攻击者可通过向ObjectMapper的readValue方法发送恶意制作的JSON输入并绕过黑名单利用该漏洞执行代码。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2018-04057
影响范围：(∞, 2.8.11)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.isea533:mybatis-spring@1.0-SNAPSHOT->com.fasterxml.jackson.core:jackson-databind@2.4.2
```
另外我运行这个项目时，IDE的安全插件提示还有85个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pbf15d